### PR TITLE
Enhance Email Verification Logic and Update BlocProvider Initialization

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -48,7 +48,8 @@ class RouterApp {
                 create: (context) => sl<CheckEmailVerificationCubit>(),
               ),
               BlocProvider(
-                create: (context) => sl<SendEmailVerificationCubit>(),
+                create: (context) =>
+                    sl<SendEmailVerificationCubit>()..sendEmailVerification(),
               ),
             ],
             child: const VerificationScreen(),

--- a/lib/features/Authentication/data/data_sources/auth_remote_data_source.dart
+++ b/lib/features/Authentication/data/data_sources/auth_remote_data_source.dart
@@ -217,7 +217,17 @@ class AuthFireBaseRemoteDataSource extends AuthRemoteDataSource {
     try {
       await checkConnection();
       await firebaseAuth.currentUser!.reload();
-      return firebaseAuth.currentUser!.emailVerified;
+      bool isVerified = firebaseAuth.currentUser!.emailVerified;
+      if (isVerified) {
+        await firebaseFirestore
+            .collection("users")
+            .doc(firebaseAuth.currentUser!.uid)
+            .update({
+          "isVerified": true,
+        });
+      }
+
+      return isVerified;
     } on NoInternetException {
       throw const NoInternetException();
     } catch (e) {


### PR DESCRIPTION
- Added logic to update the **isVerified** field in Firestore after checking if the user's email is verified.
- Modified **BlocProvider** for SendEmailVerificationCubit to immediately trigger the sendEmailVerification() method upon initialization.